### PR TITLE
Fix setup problem with puppet and python

### DIFF
--- a/ftdetect/python.vim
+++ b/ftdetect/python.vim
@@ -1,24 +1,2 @@
 " detect python filetype
 au BufRead,BufNewFile *.py    set filetype=python
-au FileType python colorscheme murphy
-
-" Wrapping and tabs.
-set tw=78 ts=4 sw=4 sta et sts=4 ai
-
-" Wrap at 78 chars for comments
-set formatoptions=cq textwidth=78 foldignore= wildignore+=*.py[co]
-
-" Smart indenting
-set smartindent cinwords=if,elif,else,for,while,try,except,finally,def,class
-
-" More syntax highlighting.
-let python_highlight_all = 1 
-
-" Auto completion via ctrl-space
-set omnifunc=pythoncomplete#Complete
-inoremap <Nul> <C-x><C-o>
-inoremap # X^H#
-
-" Highlight end of line whitespace.
-highlight WhitespaceEOL ctermbg=red guibg=red
-match WhitespaceEOL /\s\+$/

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -1,9 +1,9 @@
 " # @@@ START COPYRIGHT @@@
-" # 
+" #
 " # (C) Copyright 2015 Hewlett-Packard Development Company, L.P.
-" # 
+" #
 " # Puppet - Automating Configuration Management.
-" # 
+" #
 " # Copyright (C) 2011 Puppet Labs Inc
 " #
 " # Puppet Labs can be contacted at: info@puppetlabs.com
@@ -22,5 +22,34 @@
 " #
 " # @@@ END COPYRIGHT @@@
 "
-" detect puppet filetype
-au BufRead,BufNewFile *.pp              set filetype=puppet
+" Vim filetype plugin
+" Language: Python
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+" detect python filetype
+au FileType python colorscheme murphy
+
+" Wrapping and tabs.
+set tw=78 ts=4 sw=4 sta et sts=4 ai
+
+" Wrap at 78 chars for comments
+set formatoptions=cq textwidth=78 foldignore= wildignore+=*.py[co]
+
+" Smart indenting
+set smartindent cinwords=if,elif,else,for,while,try,except,finally,def,class
+
+" More syntax highlighting.
+let python_highlight_all = 1 
+
+" Auto completion via ctrl-space
+set omnifunc=pythoncomplete#Complete
+inoremap <Nul> <C-x><C-o>
+inoremap # X^H#
+
+" Highlight end of line whitespace.
+highlight WhitespaceEOL ctermbg=red guibg=red
+match WhitespaceEOL /\s\+$/


### PR DESCRIPTION
For files In ftdetect removed indention and other setup since
ftdetect is run every time a file is opened. The files in ftdetect
should only detect filetypes.

Moved python setup to ftplugin/python.vim
